### PR TITLE
feat: add NIST P-256 point decompression

### DIFF
--- a/src/ec/ec_p256_m31.c
+++ b/src/ec/ec_p256_m31.c
@@ -636,6 +636,75 @@ reduce_final_f256(uint32_t *d)
 }
 
 /*
+ * Compute one square root in F256. Source operand shall be less than
+ * twice the modulus.
+ */
+static void
+sqrt_f256(uint32_t *d, const uint32_t *a)
+{
+	/*
+	 * The base prime in P-256 is p = 3 (mod 4) so we can compute a
+	 * square root by exponentiation to (p + 1) / 4. In P-256, this exponent is
+	 * (p + 1) / 4 = 2^254 - 2^222 + 2^190 + 2^94
+	 *         = 0x3fffffffc0000000400000000000000000000000400000000000000000000000
+	 *
+	 * We use an addition chain to compute this exponentiation. This
+	 * addition chain can be calculated with
+	 *    go install github.com/mmcloughlin/addchain/cmd/addchain@latest
+	 *    addchain search 0x3fffffffc0000000400000000000000000000000400000000000000000000000
+	 *
+	 * resulting in
+	 *
+	 *   _10       = 2*1
+	 *   _11       = 1 + _10
+	 *   _1100     = _11 << 2
+	 *   _1111     = _11 + _1100
+	 *   _11110000 = _1111 << 4
+	 *   _11111111 = _1111 + _11110000
+	 *   x16       = _11111111 << 8 + _11111111
+	 *   x32       = x16 << 16 + x16
+	 *   return      ((x32 << 32 + 1) << 96 + 1) << 94
+	 *
+	 * Same approach as golang: https://cs.opensource.google/go/go/+/master:src/crypto/internal/nistec/p256.go;drc=a5cd894318677359f6d07ee74f9004d28b4d164c;l=459
+	 */
+	uint32_t t0[9];
+
+	square_f256(d, a);
+	mul_f256(d, d, a);
+	square_f256(t0, d);
+	for (int i=1; i<2; i++) {
+		square_f256(t0, t0);
+	}
+	mul_f256(d, d, t0);
+	square_f256(t0, d);
+	for (int i=1; i<4; i++) {
+		square_f256(t0, t0);
+	}
+	mul_f256(d, d, t0);
+	square_f256(t0, d);
+	for (int i=1; i<8; i++) {
+		square_f256(t0, t0);
+	}
+	mul_f256(d, d, t0);
+	square_f256(t0, d);
+	for (int i=1; i<16; i++) {
+		square_f256(t0, t0);
+	}
+	mul_f256(d, d, t0);
+	for (int i=0; i<32; i++) {
+	  square_f256(d, d);
+	}
+	mul_f256(d, d, a);
+	for (int i=0; i<96; i++) {
+	  square_f256(d, d);
+	}
+	mul_f256(d, d, a);
+	for (int i=0; i<94; i++) {
+	  square_f256(d, d);
+	}
+}
+
+/*
  * Jacobian coordinates for a point in P-256: affine coordinates (X,Y)
  * are such that:
  *   X = x / z^2
@@ -1032,12 +1101,8 @@ p256_add_mixed(p256_jacobian *P1, const p256_jacobian *P2)
 	return ret;
 }
 
-/*
- * Decode a P-256 point. This function does not support the point at
- * infinity. Returned value is 0 if the point is invalid, 1 otherwise.
- */
 static uint32_t
-p256_decode(p256_jacobian *P, const void *src, size_t len)
+p256_decode_uncompressed(p256_jacobian *P, const void *src, size_t len)
 {
 	const unsigned char *buf;
 	uint32_t tx[9], ty[9], t1[9], t2[9];
@@ -1090,6 +1155,99 @@ p256_decode(p256_jacobian *P, const void *src, size_t len)
 	memset(P->z, 0, sizeof P->z);
 	P->z[0] = 1;
 	return NEQ(bad, 0) ^ 1;
+}
+
+static uint32_t
+p256_decode_compressed(p256_jacobian *P, const void *src, size_t len)
+{
+	/*
+	 * Reference: https://www.secg.org/sec1-v2.pdf section 2.3.4
+	 * "Octet-String-to-Elliptic-Curve-Point Conversion"
+	 */
+	const unsigned char *buf;
+	uint32_t tx[9], ty[9], t1[9], t2[9];
+	uint32_t bad;
+	int i;
+
+	if (len != 33) {
+		return 0;
+	}
+	buf = src;
+
+	/*
+	 * First byte must be 0x02 or 0x03 (compressed format).
+	 */
+	bad = NEQ(buf[0], 0x02) &  NEQ(buf[0], 0x03);
+
+	/*
+	 * Decode the x coordinate, and check that it is lower
+	 * than the modulus.
+	 */
+	tx[8] = be8_to_le30(tx, buf + 1, 32);
+	bad |= reduce_final_f256(tx);
+
+	/*
+	 * Derive a field element \alpha from curve equation.
+	 * In the happy path, \alpha is a square, y^2.
+	 */
+	square_f256(t1, tx);
+	mul_f256(t1, tx, t1);
+	sub_f256(t1, t1, tx);
+	sub_f256(t1, t1, tx);
+	sub_f256(t1, t1, tx);
+	add_f256(t1, t1, P256_B);
+
+	/*
+	 * Take one square root of \alpha.
+	 * This is either y or -y in the happy path.
+	 */
+	sqrt_f256(ty, t1);
+	reduce_final_f256(ty);
+
+	/*
+	 * Pick the square root signaled by sender in src[0]&1.
+	 */
+	uint32_t need_swap = NEQ(buf[0]&1, ty[0]&1);
+	sub_f256(t1, F256, ty);
+	reduce_final_f256(t1);
+	CCOPY(need_swap, ty, t1, sizeof t1);
+
+	/*
+	 * Check curve equation.
+	 */
+	square_f256(t1, tx);
+	mul_f256(t1, tx, t1);
+	square_f256(t2, ty);
+	sub_f256(t1, t1, tx);
+	sub_f256(t1, t1, tx);
+	sub_f256(t1, t1, tx);
+	add_f256(t1, t1, P256_B);
+	sub_f256(t1, t1, t2);
+	reduce_final_f256(t1);
+	for (i = 0; i < 9; i ++) {
+		bad |= t1[i];
+	}
+
+	/*
+	 * Copy coordinates to the point structure.
+	 */
+	memcpy(P->x, tx, sizeof tx);
+	memcpy(P->y, ty, sizeof ty);
+	memset(P->z, 0, sizeof P->z);
+	P->z[0] = 1;
+	return NEQ(bad, 0) ^ 1;
+}
+
+/*
+ * Decode a P-256 point. This function does not support the point at
+ * infinity. Returned value is 0 if the point is invalid, 1 otherwise.
+ */
+static uint32_t
+p256_decode(p256_jacobian *P, const void *src, size_t len)
+{
+	uint32_t valid1 = p256_decode_uncompressed(P, src, len);
+	uint32_t valid2 = p256_decode_compressed(P, src, len);
+	return valid1 | valid2;
 }
 
 /*

--- a/src/ec/ecdsa_i31_vrfy_raw.c
+++ b/src/ec/ecdsa_i31_vrfy_raw.c
@@ -82,7 +82,8 @@ br_ecdsa_i31_vrfy_raw(const br_ec_impl *impl,
 	/*
 	 * Public key point must have the proper size for this curve.
 	 */
-	if (pk->qlen != cd->generator_len) {
+	if ((pk->qlen != cd->generator_len) /* uncompressed */ &&
+	    (pk->qlen != (cd->generator_len/2) + 1) /* compressed */) {
 		return 0;
 	}
 
@@ -143,8 +144,9 @@ br_ecdsa_i31_vrfy_raw(const br_ec_impl *impl,
 	 * Compute the point x*Q + y*G.
 	 */
 	ulen = cd->generator_len;
-	memcpy(eU, pk->q, ulen);
-	res = impl->muladd(eU, NULL, ulen,
+	memset(eU, 0, ulen);
+	memcpy(eU, pk->q, pk->qlen);
+	res = impl->muladd(eU, NULL, pk->qlen,
 		tx, nlen, ty, nlen, cd->curve);
 
 	/*


### PR DESCRIPTION
This PR adds minimal support for compressed points. This is only used right now in ECDSA verification over NIST P-256.

We follow [SEC 1 V2, section 2.3.4](https://www.secg.org/sec1-v2.pdf).